### PR TITLE
Add Travis deployment previews to surge.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: false
+
+language: ruby
+cache: bundler
+rvm:
+  - 2.3.3
+
+before_install:
+  - test $TRAVIS_PULL_REQUEST && ./.travis/pr_status pending "Waiting for website to build"
+
+script:
+  - bash .travis/build.sh
+
+after_success:
+  - test $TRAVIS_PULL_REQUEST && ./.travis/pr_deploy
+after_failure:
+  - test $TRAVIS_PULL_REQUEST && ./.travis/pr_status error "Website failed to build"
+
+env:
+  global:
+    - GITHUB_AUTH_USER=allejo
+    - GITHUB_USER=CityofSantaMonica
+    - GITHUB_REPO=wellbeing-findings
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+notifications:
+  email: false

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+git submodule update --init
+bundle install --path vendor/bundle
+bundle exec jekyll build
+#bundle exec htmlproofer ./_site

--- a/.travis/pr_deploy
+++ b/.travis/pr_deploy
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+URL="https://$GITHUB_USER--$GITHUB_REPO--$TRAVIS_PULL_REQUEST.surge.sh"
+if [ ! -f /usr/local/bin/surge ]; then npm install -g surge; fi
+surge --project ./_site --domain "$URL" > /dev/null
+SURGE_STATUS=$?
+STATUS=$([ $SURGE_STATUS -eq 0 ] && echo "success" || echo "failure")
+DESC=$([ $SURGE_STATUS -eq 0 ] && echo "Staging website deployed successfully" || echo "Staging website deployment failed")
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bash $DIR/pr_status "$STATUS" "$DESC" "$URL"

--- a/.travis/pr_status
+++ b/.travis/pr_status
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+STATUS=$1
+DESC=$2
+URL=$3
+
+data="{\"state\":\"$STATUS\","
+if [ ! -z "$URL" ]
+then
+    data="$data\"target_url\":\"$URL\","
+fi
+data="$data\"description\":\"$DESC\",\"context\":\"surge.sh/staging\"}"
+
+curl -u $GITHUB_AUTH_USER:$GITHUB_PR_TOKEN --data "$data" "https://api.github.com/repos/$GITHUB_USER/$GITHUB_REPO/statuses/$TRAVIS_PULL_REQUEST_SHA" > /dev/null


### PR DESCRIPTION
@thekaveman didn't know whether or not you wanted surge.sh deploys for this too but here you go!

Enable the repo: https://travis-ci.org/CityofSantaMonica/wellbeing-findings

and could I get write access to set up the tokens on Travis or I could send them to you, either way works